### PR TITLE
Add test for np-prompt using Expect

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,17 +3,40 @@ Changelog
 
 All notable changes to this project are documented in this file.
 
-[0.7.3-dev] in progress
+[0.7.6] 2018-08-02
+------------------
+- Adds test for np-prompt using expect
+- Adds ability to attach a fee to a ``send`` transaction
+- Update Node selection mechanism
+- Store ``Transactions`` list items inside a ``Block`` in a consistent format.
+- Improved peer connection maintenance
+
+
+[0.7.5] 2018-07-19
 -----------------------
-- Updated the requirements
+- Update NodeLeader peer monitoring system
+- Add ability to configure size of requests for blocks as well as block processing queue size
+- Update mainnet bootstrap files
+- Fix size calculations for all serializable classes
+- Add ``size`` key to JSON output of Block and Transaction
+- add prompt command to split VIN to multiple VOUT
+- update notification endpoint to include ``total_pages`` in output, and allow ``pagesize`` paramater to be passed in
+- update seeds for mainnet
+
+[0.7.3] 2018-07-12
+------------------
+- Updated package requirements, removed ``pycrypto`` from all dependencies to fix install error(s) `#485 <https://github.com/CityOfZion/neo-python/issues/485>`_
 - Adds option to enter arguments for smart contract in an 'interactive' mode, which allows for much better parsing of input, activated by passing the ``--i`` flag when invoking.
 - Adds ability to *not* parse address strings such as AeV59NyZtgj5AMQ7vY6yhr2MRvcfFeLWSb when inputting to smart contract by passing the ``--no-parse`` flag
 - Changes the structure of items dispatched in SmartContractEvents to use the ``ContractParameter`` interface for better type inference and variable usage.
+- Fix sending NEP5 tokesn from a multisig address.
 - Bugfix: np-api-server with open wallet now properly processes new blocks
+- Update neo-boa to v0.4.8 and neocore to v0.4.11
+- Add VM support for ``Neo.Contract.IsPayable``
 
 
 [0.7.2] 2018-06-21
--------------------
+------------------
 - When using a custom datadir (with ``--datadir``), ``np-prompt`` will store log and history files there instead of
   the default directory. Note: if you use a custom datadir that does not yet exist, ``np-prompt`` starts without
   history or logs because those files are just created from scratch in the custom datadir.
@@ -113,7 +136,7 @@ All notable changes to this project are documented in this file.
 
 
 [0.6.5] 2018-03-31
------------------------
+------------------
 - Changed the ``eval()`` call when parsing the `--tx-attr` param to parse only json. Reduced the surface and options available on the other 2 eval calls to improve security.
 - fix wallet rebuild database lock errors (`PR #365 <https://github.com/CityOfZion/neo-python/pull/365>`_)
 - Fixed `synced_watch_only_balances` being always zero issue (`#209  <https://github.com/CityOfZion/neo-python/issues/209>`_)

--- a/neo/bin/test_prompt.py
+++ b/neo/bin/test_prompt.py
@@ -1,0 +1,36 @@
+from unittest import TestCase
+import pexpect
+
+class PromptTest(TestCase):
+
+    def test_prompt_run(self):
+
+        child = pexpect.spawn('np-prompt')
+        index = child.expect(["neo", pexpect.EOF, pexpect.TIMEOUT])
+        
+        if index == 0:
+            print('np-prompt running as expected')
+        elif index == 1:
+            print('np-prompt experienced an unexpected EOF')
+        elif index == 2:
+            print('np-prompt experienced an unexpected TIMEOUT')
+        elif index != 0 and index != 1 and index != 2:
+            print('test failed')
+
+        self.assertEqual(index, 0)
+
+    def test_prompt_open_wallet(self):
+
+        child = pexpect.spawn('np-prompt')
+        child.expect("neo")
+        child.sendline('open wallet fixtures/testwallet.db3')
+        child.expect(pexpect.TIMEOUT)
+        child.sendline('testpassword')
+        index = child.expect(['Opened wallet at fixtures/testwallet.db3'])
+
+        if index == 0:
+            print('Opened testwallet.db3 successfully')
+        elif index != 0:
+            print('test failed')
+
+        self.assertEqual(index, 0)


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
This addresses issue #490
Adds test_prompt.py

**How did you solve this problem?**
Learned about pexpect, trial and error

**How did you make sure your solution works?**
Tested using unittest

**Are there any special changes in the code that we should be aware of?**
Requires installing pexpect in venv

**Please check the following, if applicable:**

- [x] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
