### PR TITLE
Fix 1 word commands (#727)

### DIFF
--- a/neo/bin/prompt.py
+++ b/neo/bin/prompt.py
@@ -985,7 +985,7 @@ class PromptInterface:
                     if command in self.commands:
                         cmd = self.commands[command]
 
-                        if arguments[-1] == 'help':
+                        if len(arguments) > 0 and arguments[-1] == 'help':
                             cmd.handle_help(arguments)
                         else:
                             cmd.execute(arguments)


### PR DESCRIPTION
* Improve CommandBase.register_sub_command to use the subcommand's CommandDesc.command as an id.

Signed-off-by: Guillaume George <lysandergc@gmail.com>

* Fix exception when a command was used without arguments (for example "wallet")

Signed-off-by: Guillaume George <lysandergc@gmail.com>